### PR TITLE
CI: Add local feed for CI-built packages

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -2,7 +2,12 @@
 
 # not enabling `errtrace` and `pipefail` since those are bash specific
 set -o errexit # failing commands causes script to fail
-set -o nounset # undefined variables causes script to fail 
+set -o nounset # undefined variables causes script to fail
+
+echo "src/gz packages_ci file:///ci" >> /etc/opkg/distfeeds.conf
+
+FINGERPRINT="$(usign -F -p /ci/packages_ci.pub)"
+cp /ci/packages_ci.pub "/etc/opkg/keys/$FINGERPRINT"
 
 mkdir -p /var/lock/
 
@@ -11,7 +16,7 @@ opkg update
 [ -n "${CI_HELPER:=''}" ] || CI_HELPER="/ci/.github/workflows/ci_helpers.sh"
 
 for PKG in /ci/*.ipk; do
-	tar -xzOf "$PKG" ./control.tar.gz | tar xzf - ./control 
+	tar -xzOf "$PKG" ./control.tar.gz | tar xzf - ./control
 	# package name including variant
 	PKG_NAME=$(sed -ne 's#^Package: \(.*\)$#\1#p' ./control)
 	# package version without release

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -82,14 +82,25 @@ jobs:
           echo "Building $PACKAGES"
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
+      - name: Generate build keys
+        run: |
+          sudo apt-get install -y signify-openbsd
+          signify-openbsd -G -n -c 'DO NOT USE - OpenWrt packages feed CI' -p packages_ci.pub -s packages_ci.sec
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "KEY_BUILD<<$EOF" >> $GITHUB_ENV
+          cat packages_ci.sec >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
+
       - name: Build
         uses: openwrt/gh-action-sdk@v5
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: packages_ci
+          INDEX: 1
+          KEY_BUILD: ${{ env.KEY_BUILD }}
 
       - name: Move created packages to project dir
-        run: cp bin/packages/${{ matrix.arch }}/packages_ci/*.ipk . || true
+        run: cp bin/packages/${{ matrix.arch }}/packages_ci/* . || true
 
       - name: Collect metadata
         run: |
@@ -132,6 +143,8 @@ jobs:
         with:
           name: ${{env.ARCHIVE_NAME}}-packages
           path: |
+            Packages
+            Packages.*
             *.ipk
             PKG-INFO
 

--- a/utils/test-bar/Makefile
+++ b/utils/test-bar/Makefile
@@ -1,0 +1,23 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=test-bar
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/test-bar
+  SUBMENU:=Compression
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=https://example.com
+  TITLE:=test-bar
+endef
+
+Build/Compile:=:
+
+define Package/test-bar/install
+	touch $(1)/test-bar
+endef
+
+$(eval $(call BuildPackage,test-bar))

--- a/utils/test-foo/Makefile
+++ b/utils/test-foo/Makefile
@@ -1,0 +1,24 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=test-foo
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/test-foo
+  SUBMENU:=Compression
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=https://example.com
+  TITLE:=test-foo
+  DEPENDS:=+test-bar
+endef
+
+Build/Compile:=:
+
+define Package/test-foo/install
+	touch $(1)/test-foo
+endef
+
+$(eval $(call BuildPackage,test-foo))


### PR DESCRIPTION
To test each package, the CI-built target package (ipk) file is installed, but currently the target package's dependencies are installed from the standard opkg feeds.

There are cases when the CI-built target packages should be installed/tested together:

* If a pull request contains several new packages that depend on each other, the test step will fail as the new dependencies cannot be found in the current packages feed.

* If a pull request upgrades a source package that builds several target packages that depend on each other, the test step may fail due to the version/ABI mismatch between a newer target package and the older dependencies installed from the packages feed.

This sets up a local feed for the CI-built packages so that dependencies are also installed from the same set of packages.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
