### PR TITLE
CI: Fix finding test script

### DIFF
--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -21,14 +21,27 @@ for PKG in /ci/*.ipk; do
 	PKG_NAME=$(sed -ne 's#^Package: \(.*\)$#\1#p' ./control)
 	# package version without release
 	PKG_VERSION=$(sed -ne 's#^Version: \(.*\)-[0-9]*$#\1#p' ./control)
-	# package source contianing test.sh script
-	PKG_SOURCE=$(sed -ne 's#^Source: .*/\(.*\)$#\1#p' ./control)
+	# package source containing test.sh script
+	PKG_SOURCE=$(sed -ne 's#^Source: \(.*\)$#\1#p' ./control)
+	PKG_SOURCE="${PKG_SOURCE#/feed/}"
 
+	echo
 	echo "Testing package $PKG_NAME in version $PKG_VERSION from $PKG_SOURCE"
 
-	export PKG_NAME PKG_VERSION CI_HELPER
+	if ! [ -d "/ci/$PKG_SOURCE" ]; then
+		echo "$PKG_SOURCE is not a directory"
+		exit 1
+	fi
 
-	PRE_TEST_SCRIPT=$(find /ci/ -name "$PKG_SOURCE" -type d)/pre-test.sh
+	PRE_TEST_SCRIPT="/ci/$PKG_SOURCE/pre-test.sh"
+	TEST_SCRIPT="/ci/$PKG_SOURCE/test.sh"
+
+	if ! [ -f "$TEST_SCRIPT" ]; then
+		echo "No test.sh script available"
+		continue
+	fi
+
+	export PKG_NAME PKG_VERSION CI_HELPER
 
 	if [ -f "$PRE_TEST_SCRIPT" ]; then
 		echo "Use package specific pre-test.sh"
@@ -44,18 +57,12 @@ for PKG in /ci/*.ipk; do
 
 	opkg install "$PKG"
 
-	TEST_SCRIPT=$(find /ci/ -name "$PKG_SOURCE" -type d)/test.sh
-
-	if [ -f "$TEST_SCRIPT" ]; then
-		echo "Use package specific test.sh"
-		if sh "$TEST_SCRIPT" "$PKG_NAME" "$PKG_VERSION"; then
-			echo "Test successful"
-		else
-			echo "Test failed"
-			exit 1
-		fi
+	echo "Use package specific test.sh"
+	if sh "$TEST_SCRIPT" "$PKG_NAME" "$PKG_VERSION"; then
+		echo "Test successful"
 	else
-		echo "No test.sh script available"
+		echo "Test failed"
+		exit 1
 	fi
 
 	opkg remove "$PKG_NAME" --force-removal-of-dependent-packages --force-remove --autoremove || true

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -12,7 +12,7 @@ GO_VERSION_PATCH:=5
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 GO_SOURCE_URLS:=https://dl.google.com/go/ \
                 https://mirrors.ustc.edu.cn/golang/ \

--- a/lang/golang/golang/test.sh
+++ b/lang/golang/golang/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = golang ] || exit 0
+
+go version | grep -F " go$PKG_VERSION "


### PR DESCRIPTION
Currently, the run test code tries to find the package source directory based on the directory name only. This fails for the Go compiler package because there is more than one directory named "golang".

This uses the full path listed in the "Source:" line of the control file to find the package source directory.

This also checks for the test script earlier, to avoid installing and removing ipk files when there is no test script to be run.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
